### PR TITLE
Print SHT4x temperature and delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 
+### Added
+- Serial print of SHT4x temperature and temperature
+  difference between STC3x and SHT4x to compensation
+  example.
+
 ## [1.0.0] - 2024-3-4
 
 ### Added

--- a/measurement-with-compensation/stc3x_i2c_measurement_with_compensation.c
+++ b/measurement-with-compensation/stc3x_i2c_measurement_with_compensation.c
@@ -139,7 +139,10 @@ int main(void) {
         // Print CO2 concentration in Vol% and temperature in degree celsius.
         //
         printf("CO2 concentration = %.2f\n", stc3x_co2_concentration);
-        printf("Temperature = %.2f\n", stc3x_temperature);
+        printf("Temperature STC3x = %.2f\n", stc3x_temperature);
+        printf("Temperature SHT4x = %.2f\n", sht4x_temperature);
+        printf("Temperature Delta = %.2f\n",
+               stc3x_temperature - sht4x_temperature);
     }
 
     return NO_ERROR;


### PR DESCRIPTION
Add console prints for SHT4x temperature and temperature delta between stc3x and sht4x in compensation example.